### PR TITLE
Update getDropZoneProps to pass the event object

### DIFF
--- a/src/Files.js
+++ b/src/Files.js
@@ -234,11 +234,11 @@ class Files extends React.Component<Props> {
                             ...rest,
                             onDragOver: e => {
                                 e.preventDefault();
-                                typeof onDragOver === "function" && onDragOver();
+                                typeof onDragOver === "function" && onDragOver(e);
                             },
                             onDrop: async e => {
                                 e.preventDefault();
-                                typeof onDrop === "function" && onDrop();
+                                typeof onDrop === "function" && onDrop(e);
                                 this.onDropFilesHandler({ e, onSuccess, onError });
                             }
                         };


### PR DESCRIPTION
Currently, any custom handlers for onDragOver and onDrop do not receive the event object. This unobtrusive code change allows developers to access the event object.

## Related Issue
Well, take it or leave it, this change is so small I'm not going to open an issue. Either merge or delete the PR.

## Your solution
Just pass the event object. It was probably an oversight.

## How Has This Been Tested?
Shouldn't need testing

## Screenshots (if relevant):
N/A